### PR TITLE
npm系の依存をglobalからlocalに変更し、キャッシュビルドを有効化

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -59,7 +59,8 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: 16
-      - name: install-dependency
+          cache: 'npm'
+      - name: install dependency
         run: npm ci
       - name: deploy api gateway
         if: contains(needs.test-python.outputs.changed-files, 'api-gateway/')

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -59,23 +59,16 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: 16
-      - run: npm install -g serverless
-      - run: npm install -g serverless-python-requirements
-      - run: npm install -g serverless-wsgi
-      - run: npm install -g serverless-cloudformation-sub-variables
+      - name: install-dependency
+        run: npm ci
       - name: deploy api gateway
         if: contains(needs.test-python.outputs.changed-files, 'api-gateway/')
-        run: |
-          cd api-gateway
-          sls deploy
-          cd ..
+        run: npm run deploy_apigw
       - name: deploy apis
         run: |
           lambdas=($(ls | grep _api))
           for lambda in ${lambdas[@]}; do
             if [[ "${{needs.test-python.outputs.changed-files}}" =~ "$lambda" ]]; then
-              cd ${lambda}
-              sls deploy
-              cd ..
+              npm run deploy_api --apiname=${lambda}
             fi
           done

--- a/.gitignore
+++ b/.gitignore
@@ -344,3 +344,6 @@ pip-selfcheck.json
 .ionide
 
 # End of https://www.toptal.com/developers/gitignore/api/macos,venv,pycharm,visualstudiocode,python
+
+# npm dependency
+node_modules

--- a/package-lock.json
+++ b/package-lock.json
@@ -2253,9 +2253,9 @@
             }
         },
         "node_modules/dezalgo": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.3.tgz",
-            "integrity": "sha512-K7i4zNfT2kgQz3GylDw40ot9GAE47sFZ9EXHFSPP6zONLgH6kWXE0KWJchkbQJLBkRazq4APwZ4OwiFFlT95OQ==",
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.4.tgz",
+            "integrity": "sha512-rXSP0bf+5n0Qonsb+SVVfNfIsimO4HEtmnIpPHY8Q1UCzKlQrDMfdobr8nJOOsRgWCyMRqeSBQzmWUMq7zvVig==",
             "dependencies": {
                 "asap": "^2.0.0",
                 "wrappy": "1"
@@ -2867,28 +2867,17 @@
             }
         },
         "node_modules/formidable": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/formidable/-/formidable-2.0.1.tgz",
-            "integrity": "sha512-rjTMNbp2BpfQShhFbR3Ruk3qk2y9jKpvMW78nJgx8QKtxjDVrwbZG+wvDOmVbifHyOUOQJXxqEy6r0faRrPzTQ==",
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/formidable/-/formidable-2.1.1.tgz",
+            "integrity": "sha512-0EcS9wCFEzLvfiks7omJ+SiYJAiD+TzK4Pcw1UlUoGnhUxDcMKjt0P7x8wEb0u6OHu8Nb98WG3nxtlF5C7bvUQ==",
             "dependencies": {
-                "dezalgo": "1.0.3",
-                "hexoid": "1.0.0",
-                "once": "1.4.0",
-                "qs": "6.9.3"
+                "dezalgo": "^1.0.4",
+                "hexoid": "^1.0.0",
+                "once": "^1.4.0",
+                "qs": "^6.11.0"
             },
             "funding": {
                 "url": "https://ko-fi.com/tunnckoCore/commissions"
-            }
-        },
-        "node_modules/formidable/node_modules/qs": {
-            "version": "6.9.3",
-            "resolved": "https://registry.npmjs.org/qs/-/qs-6.9.3.tgz",
-            "integrity": "sha512-EbZYNarm6138UKKq46tdx08Yo/q9ZhFoAXAI1meAFd2GtbRDhbZY2WQSICskT0c5q99aFzLG1D4nvTk9tqfXIw==",
-            "engines": {
-                "node": ">=0.6"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
             }
         },
         "node_modules/fs-constants": {
@@ -5484,9 +5473,9 @@
             "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="
         },
         "node_modules/simple-git": {
-            "version": "3.14.1",
-            "resolved": "https://registry.npmjs.org/simple-git/-/simple-git-3.14.1.tgz",
-            "integrity": "sha512-1ThF4PamK9wBORVGMK9HK5si4zoGS2GpRO7tkAFObA4FZv6dKaCVHLQT+8zlgiBm6K2h+wEU9yOaFCu/SR3OyA==",
+            "version": "3.15.1",
+            "resolved": "https://registry.npmjs.org/simple-git/-/simple-git-3.15.1.tgz",
+            "integrity": "sha512-73MVa5984t/JP4JcQt0oZlKGr42ROYWC3BcUZfuHtT3IHKPspIvL0cZBnvPXF7LL3S/qVeVHVdYYmJ3LOTw4Rg==",
             "dependencies": {
                 "@kwsites/file-exists": "^1.1.1",
                 "@kwsites/promise-deferred": "^1.1.1",
@@ -8217,9 +8206,9 @@
             "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ=="
         },
         "dezalgo": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.3.tgz",
-            "integrity": "sha512-K7i4zNfT2kgQz3GylDw40ot9GAE47sFZ9EXHFSPP6zONLgH6kWXE0KWJchkbQJLBkRazq4APwZ4OwiFFlT95OQ==",
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.4.tgz",
+            "integrity": "sha512-rXSP0bf+5n0Qonsb+SVVfNfIsimO4HEtmnIpPHY8Q1UCzKlQrDMfdobr8nJOOsRgWCyMRqeSBQzmWUMq7zvVig==",
             "requires": {
                 "asap": "^2.0.0",
                 "wrappy": "1"
@@ -8666,21 +8655,14 @@
             }
         },
         "formidable": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/formidable/-/formidable-2.0.1.tgz",
-            "integrity": "sha512-rjTMNbp2BpfQShhFbR3Ruk3qk2y9jKpvMW78nJgx8QKtxjDVrwbZG+wvDOmVbifHyOUOQJXxqEy6r0faRrPzTQ==",
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/formidable/-/formidable-2.1.1.tgz",
+            "integrity": "sha512-0EcS9wCFEzLvfiks7omJ+SiYJAiD+TzK4Pcw1UlUoGnhUxDcMKjt0P7x8wEb0u6OHu8Nb98WG3nxtlF5C7bvUQ==",
             "requires": {
-                "dezalgo": "1.0.3",
-                "hexoid": "1.0.0",
-                "once": "1.4.0",
-                "qs": "6.9.3"
-            },
-            "dependencies": {
-                "qs": {
-                    "version": "6.9.3",
-                    "resolved": "https://registry.npmjs.org/qs/-/qs-6.9.3.tgz",
-                    "integrity": "sha512-EbZYNarm6138UKKq46tdx08Yo/q9ZhFoAXAI1meAFd2GtbRDhbZY2WQSICskT0c5q99aFzLG1D4nvTk9tqfXIw=="
-                }
+                "dezalgo": "^1.0.4",
+                "hexoid": "^1.0.0",
+                "once": "^1.4.0",
+                "qs": "^6.11.0"
             }
         },
         "fs-constants": {
@@ -10526,9 +10508,9 @@
             "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="
         },
         "simple-git": {
-            "version": "3.14.1",
-            "resolved": "https://registry.npmjs.org/simple-git/-/simple-git-3.14.1.tgz",
-            "integrity": "sha512-1ThF4PamK9wBORVGMK9HK5si4zoGS2GpRO7tkAFObA4FZv6dKaCVHLQT+8zlgiBm6K2h+wEU9yOaFCu/SR3OyA==",
+            "version": "3.15.1",
+            "resolved": "https://registry.npmjs.org/simple-git/-/simple-git-3.15.1.tgz",
+            "integrity": "sha512-73MVa5984t/JP4JcQt0oZlKGr42ROYWC3BcUZfuHtT3IHKPspIvL0cZBnvPXF7LL3S/qVeVHVdYYmJ3LOTw4Rg==",
             "requires": {
                 "@kwsites/file-exists": "^1.1.1",
                 "@kwsites/promise-deferred": "^1.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,11 +8,11 @@
             "name": "serverless-development",
             "version": "1.0.0",
             "dependencies": {
-                "serverless-cloudformation-sub-variables": "^0.2.1",
                 "serverless-offline": "^11.1.3"
             },
             "devDependencies": {
                 "serverless": "^3.2.1",
+                "serverless-cloudformation-sub-variables": "^0.2.1",
                 "serverless-python-requirements": "^5.1.0",
                 "serverless-wsgi": "^3.0.1"
             }
@@ -5255,7 +5255,8 @@
         "node_modules/serverless-cloudformation-sub-variables": {
             "version": "0.2.1",
             "resolved": "https://registry.npmjs.org/serverless-cloudformation-sub-variables/-/serverless-cloudformation-sub-variables-0.2.1.tgz",
-            "integrity": "sha512-ClknmsdUx+aUakbNo0aP4L0SwwM+Bd/HtjOdgJVDqWuNQlQsDr4ajX/nM5nABseFsIQhzyoSq5F6xgnajloWuQ=="
+            "integrity": "sha512-ClknmsdUx+aUakbNo0aP4L0SwwM+Bd/HtjOdgJVDqWuNQlQsDr4ajX/nM5nABseFsIQhzyoSq5F6xgnajloWuQ==",
+            "dev": true
         },
         "node_modules/serverless-offline": {
             "version": "11.1.3",
@@ -10357,7 +10358,8 @@
         "serverless-cloudformation-sub-variables": {
             "version": "0.2.1",
             "resolved": "https://registry.npmjs.org/serverless-cloudformation-sub-variables/-/serverless-cloudformation-sub-variables-0.2.1.tgz",
-            "integrity": "sha512-ClknmsdUx+aUakbNo0aP4L0SwwM+Bd/HtjOdgJVDqWuNQlQsDr4ajX/nM5nABseFsIQhzyoSq5F6xgnajloWuQ=="
+            "integrity": "sha512-ClknmsdUx+aUakbNo0aP4L0SwwM+Bd/HtjOdgJVDqWuNQlQsDr4ajX/nM5nABseFsIQhzyoSq5F6xgnajloWuQ==",
+            "dev": true
         },
         "serverless-offline": {
             "version": "11.1.3",

--- a/package.json
+++ b/package.json
@@ -5,11 +5,11 @@
     "author": "",
     "devDependencies": {
         "serverless": "^3.2.1",
+        "serverless-cloudformation-sub-variables": "^0.2.1",
         "serverless-python-requirements": "^5.1.0",
         "serverless-wsgi": "^3.0.1"
     },
     "dependencies": {
-        "serverless-cloudformation-sub-variables": "^0.2.1",
         "serverless-offline": "^11.1.3"
     }
 }

--- a/package.json
+++ b/package.json
@@ -3,6 +3,10 @@
     "version": "1.0.0",
     "description": "Environment to develop serverless applications",
     "author": "",
+    "scripts": {
+        "deploy_apigw": "cd api-gateway && sls deploy",
+        "deploy_api": "cd $npm_config_apiname && sls deploy"
+    },
     "devDependencies": {
         "serverless": "^3.2.1",
         "serverless-cloudformation-sub-variables": "^0.2.1",


### PR DESCRIPTION
ビルドの高速化と安定化のために、npm系の依存を基本ローカルにした上で、npm scriptsを利用する形に変更しました。
ついでにキャッシュビルドを有効化しました（知らんうちにargument一発でOKになってた、、、）

一旦devのみ変更してPRしますので、動作確認していただければと思いますー